### PR TITLE
Initial implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+default:
+	@echo "Targets:"
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+
+test:
+	python3 setup.py register -r pypitest
+	python3 setup.py sdist bdist_wheel upload -r pypitest
+
+publish: test
+	python3 setup.py sdist bdist_wheel upload

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ c.CarinaSpawner.hub_ip_connect = "<jupyterhub_domain>"
 You can customize how the user's Jupyter server is created or how your OAuth credentials are specified.
 
 * `<cluster_name>`: The name of the Carina cluster to create for users. Defaults to `jupyterhub`.
-* `<container_prefix>`: The prefix for the container running the user's server. Defaults to `jupyter`, resulting in a
-    container named `jupyter-<username>`.
+* `<container_name>`: The name of the Jupyter server container running on the user's cluster. Defaults to `jupyter`.
 * `<container_image>`: The name of the image to use for the user's server. Defaults to `jupyter/singleuser`.
 *  `<start_timeout>`: The timeout when starting a user's server, this value must account for cluster creation and
     pulling the `container_image`. Defaults to `300` (5 minutes), but may need to be increased depending on the

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ You can customize how the user's Jupyter server is created or how your OAuth cre
 * `<container_prefix>`: The prefix for the container running the user's server. Defaults to `jupyter`, resulting in a
     container named `jupyter-<username>`.
 * `<container_image>`: The name of the image to use for the user's server. Defaults to `jupyter/singleuser`.
+*  `<start_timeout>`: The timeout when starting a user's server, this value must account for cluster creation and
+    pulling the `container_image`. Defaults to `300` (5 minutes), but may need to be increased depending on the
+    size of `container_image`.
 * `<cluster_polling_interval>`: The number of seconds between polling for a user's Carina cluster to become active.
     Defaults to `30` seconds.
 * `<client_id_env>`: The environment variable containing your Carina OAuth Application Id.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
 # jupyterhub-carina
-JupyterHub integration with Carina
+Carina support for JupyterHub. Authenticate your users with Carina, then run their Jupyter servers on their own Carina clusters.
+
+For an example of what this looks like, head over to [howtowhale.com](https://howtowhale.com) and sign in with your Carina account.
+
+# Installation
+`pip install jupyterhub-carina`
+
+# Prerequisites
+JupyterHub communicates with Carina using OAuth. Before your JupyterHub installation can integrate with Carina, you must
+first register the application. See the [Carina OAuth documentation][carina-oauth] for instructions on how to register. When asked for the **Redirect URI**, use the following format `https://<jupyterhub_domain>/jupyter/hub/oauth_callback`. The registered callback or redirect URL must match the value in your JupyterHub configuration file.
+
+After you have registered, note the **Application Id**, **Secret** and **Callback URL** because they are required
+in order to configure your JupyterHub server to use Carina.
+
+# Configuration
+
+1. Set the `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` environment variables, or use the optional configuration values in the next section to specify your OAuth credentials.
+2. Update your [JupyterHub's configuration file][jupyterhub-config], **jupyterhub_config.py**, with the required configuration settings. Replace the placeholder values (denoted with angle brackets) with appropriate values.
+    * `<carina_username>`: The username or email address that you use to log into [http://getcarina.com][carina].
+    * `<jupyterhub_domain>`: The domain name or IP address of your JupyterHub server.
+
+Below is an example configuration file with only the required values specified:
+
+```python
+c = get_config()
+
+# Required: Configure JupyterHub to authenticate against Carina
+c.JupyterHub.authenticator_class = "jupyterhub_carina.CarinaAuthenticator"
+c.CarinaAuthenticator.admin_users = ["<carina_username>"]
+c.CarinaAuthenticator.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/hub/oauth_callback"
+
+# Required: Configure JupyterHub to spawn user servers on Carina
+c.JupyterHub.hub_ip = "0.0.0.0"
+c.JupyterHub.spawner_class = "jupyterhub_carina.CarinaSpawner"
+c.CarinaSpawner.hub_ip_connect = "<jupyterhub_domain>"
+c.CarinaSpawner.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/hub/oauth_callback"
+```
+
+## Optional Variables
+You can customize how the user's Jupyter server is created or how your OAuth credentials are specified.
+
+* `<cluster_name>`: The name of the Carina cluster to create for users. Defaults to `jupyterhub`.
+* `<container_prefix>`: The prefix for the container running the user's server. Defaults to `jupyter`, resulting in a
+    container named `jupyter-<username>`.
+* `<container_image>`: The name of the image to use for the user's server. Defaults to `jupyter/singleuser`.
+* `<cluster_polling_interval>`: The number of seconds between polling for a user's Carina cluster to become active.
+    Defaults to `30` seconds.
+* `<client_id_env>`: The environment variable containing your Carina OAuth Application Id.
+    Defaults to `OAUTH_CLIENT_ID`.
+* `<client_secret_env>`: The environment variable containing your Carina OAuth Secret.
+    Defaults to `OAUTH_CLIENT_SECRET`.
+* `<client_id>`: Your Carina OAuth Application Id. Defaults to the value found in the `<client_id_env>` environment variable.
+    For example, you may load this from a config file. _Do NOT hard code this values and check it in!_
+* `<client_secret>`: Your Carina OAuth Secret. Defaults to the value found in the `<client_secret_env>` environment variable.
+    For example, you may load this from a config file. _Do NOT hard code this values and check it in!_
+
+Below is an example configuration file with all required and optional values specified:
+
+```python
+c = get_config()
+
+# Required: Configure JupyterHub to authenticate against Carina
+c.JupyterHub.authenticator_class = "jupyterhub_carina.CarinaAuthenticator"
+c.CarinaAuthenticator.admin_users = ["<carina_username>"]
+c.CarinaAuthenticator.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/hub/oauth_callback"
+
+# Required: Configure JupyterHub to spawn user servers on Carina
+c.JupyterHub.hub_ip = "0.0.0.0"
+c.JupyterHub.spawner_class = "jupyterhub_carina.CarinaSpawner"
+c.CarinaSpawner.hub_ip_connect = "<jupyterhub_domain>"
+c.CarinaSpawner.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/hub/oauth_callback"
+
+# Optional: Tweak how the CarinaSpawner creates the user's Carina cluster and container
+c.CarinaSpawner.cluster_name = "<cluster_name>"
+c.CarinaSpawner.container_prefix = "<container_prefix>"
+c.CarinaSpawner.container_image = "<container_image>"
+c.CarinaSpawner.cluster_polling_interval = "<cluster_polling_interval>"
+
+# Optional: Tweak where your Carina OAuth application's credentials are located
+c.CarinaAuthenticator.client_id_env = "<client_id_env>"
+c.CarinaSpawner.client_id_env = "<client_id_env>"
+c.CarinaAuthenticator.client_secret_env = "<client_secret_env>"
+c.CarinaSpawner.client_secret_env = "<client_secret_env>"
+
+# Optional: Directly specify your Carina OAuth application's credentials
+c.CarinaAuthenticator.client_id = "<client_id>"
+c.CarinaSpawner.client_id = "<client_id>"
+c.CarinaAuthenticator.client_secret = "<client_secret>"
+c.CarinaSpawner.client_secret = "<client_secret>"
+```
+
+[carina]: http://getcarina.com
+[carina-oauth]: https://getcarina.com/docs/reference/oauth-integration/#register-your-application
+[jupyterhub-config]: http://jupyterhub.readthedocs.org/en/latest/getting-started.html#how-to-configure-jupyterhub

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ c.CarinaAuthenticator.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/
 c.JupyterHub.hub_ip = "0.0.0.0"
 c.JupyterHub.spawner_class = "jupyterhub_carina.CarinaSpawner"
 c.CarinaSpawner.hub_ip_connect = "<jupyterhub_domain>"
-c.CarinaSpawner.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/hub/oauth_callback"
 ```
 
 ## Optional Variables
@@ -69,7 +68,6 @@ c.CarinaAuthenticator.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/
 c.JupyterHub.hub_ip = "0.0.0.0"
 c.JupyterHub.spawner_class = "jupyterhub_carina.CarinaSpawner"
 c.CarinaSpawner.hub_ip_connect = "<jupyterhub_domain>"
-c.CarinaSpawner.oauth_callback_url = "https://<jupyterhub_domain>/jupyter/hub/oauth_callback"
 
 # Optional: Tweak how the CarinaSpawner creates the user's Carina cluster and container
 c.CarinaSpawner.cluster_name = "<cluster_name>"
@@ -79,15 +77,11 @@ c.CarinaSpawner.cluster_polling_interval = "<cluster_polling_interval>"
 
 # Optional: Tweak where your Carina OAuth application's credentials are located
 c.CarinaAuthenticator.client_id_env = "<client_id_env>"
-c.CarinaSpawner.client_id_env = "<client_id_env>"
 c.CarinaAuthenticator.client_secret_env = "<client_secret_env>"
-c.CarinaSpawner.client_secret_env = "<client_secret_env>"
 
 # Optional: Directly specify your Carina OAuth application's credentials
 c.CarinaAuthenticator.client_id = "<client_id>"
-c.CarinaSpawner.client_id = "<client_id>"
 c.CarinaAuthenticator.client_secret = "<client_secret>"
-c.CarinaSpawner.client_secret = "<client_secret>"
 ```
 
 [carina]: http://getcarina.com

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ c.CarinaSpawner.hub_ip_connect = "<jupyterhub_domain>"
 ## Optional Variables
 You can customize how the user's Jupyter server is created or how your OAuth credentials are specified.
 
-* `<cluster_name>`: The name of the Carina cluster to create for users. Defaults to `jupyterhub`.
+* `<cluster_name>`: The name of the user's Carina cluster. Defaults to `jupyterhub`.
 * `<container_name>`: The name of the Jupyter server container running on the user's cluster. Defaults to `jupyter`.
 * `<container_image>`: The name of the image to use for the user's server. Defaults to `jupyter/singleuser`.
 *  `<start_timeout>`: The timeout when starting a user's server, this value must account for cluster creation and
     pulling the `container_image`. Defaults to `300` (5 minutes), but may need to be increased depending on the
     size of `container_image`.
-* `<cluster_polling_interval>`: The number of seconds between polling for a user's Carina cluster to become active.
+* `<cluster_polling_interval>`: The number of seconds between polling for a user's cluster to become active.
     Defaults to `30` seconds.
 * `<client_id_env>`: The environment variable containing your Carina OAuth Application Id.
     Defaults to `OAUTH_CLIENT_ID`.

--- a/jupyterhub_carina/CarinaAuthenticator.py
+++ b/jupyterhub_carina/CarinaAuthenticator.py
@@ -9,6 +9,7 @@ class CarinaLoginHandler(OAuthLoginHandler, OAuth2Mixin):
     """
     Carina OAuth dance magic
     """
+
     _OAUTH_AUTHORIZE_URL = CarinaOAuthClient.CARINA_AUTHORIZE_URL
     _OAUTH_ACCESS_TOKEN_URL = CarinaOAuthClient.CARINA_TOKEN_URL
 
@@ -17,7 +18,7 @@ class CarinaLoginHandler(OAuthLoginHandler, OAuth2Mixin):
 
 class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
     """
-    Authenticate users with their Carina account.
+    Authenticate users with their Carina account
     """
 
     # Configure the base OAuthenticator
@@ -37,7 +38,6 @@ class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
         """
         Complete the OAuth dance and identify the user
         """
-
         authorization_code = handler.get_argument("code", False)
         if not authorization_code:
             raise web.HTTPError(400, "OAuth callback made without a token")
@@ -56,9 +56,8 @@ class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
 
     def pre_spawn_start(self, user, spawner):
         """
-        Update the spawner with the OAuth credentials from the last time the user signed in
+        Update the spawner with the most recent OAuth credentials
         """
-
         creds = self.carina_client.credentials
         if creds is None:
             return

--- a/jupyterhub_carina/CarinaAuthenticator.py
+++ b/jupyterhub_carina/CarinaAuthenticator.py
@@ -48,14 +48,11 @@ class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
         carina_username = profile['username']
         self.carina_client.user = carina_username
 
-        # map username to system username
-        system_username = self.username_map.get(carina_username, carina_username)
+        # verify that the user is authorized on this system
+        if self.whitelist and carina_username not in self.whitelist:
+            carina_username = None
 
-        # check system username against whitelist
-        if self.whitelist and system_username not in self.whitelist:
-            system_username = None
-
-        return system_username
+        return carina_username
 
     def pre_spawn_start(self, user, spawner):
         """

--- a/jupyterhub_carina/CarinaAuthenticator.py
+++ b/jupyterhub_carina/CarinaAuthenticator.py
@@ -1,0 +1,58 @@
+from tornado.auth import OAuth2Mixin
+from tornado import gen, web
+from traitlets import Dict
+from traitlets.config import LoggingConfigurable
+from oauthenticator import OAuthLoginHandler, OAuthenticator
+from .CarinaOAuthClient import CarinaOAuthClient
+
+
+class CarinaMixin(OAuth2Mixin):
+    _OAUTH_AUTHORIZE_URL = CarinaOAuthClient.CARINA_AUTHORIZE_URL
+    _OAUTH_ACCESS_TOKEN_URL = CarinaOAuthClient.CARINA_TOKEN_URL
+
+
+class CarinaLoginHandler(OAuthLoginHandler, CarinaMixin):
+    scope = ['identity', 'cluster_credentials', 'create_cluster']
+
+
+class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
+    # Configure the base OAuthenticator
+    login_service = 'Carina'
+    login_handler = CarinaLoginHandler
+
+    # Expose configuration options
+    username_map = Dict(config=True, default_value={},
+                        help="""Optional dict to remap github usernames to system usernames.
+
+        User github usernames for keys and existing system usernames as values.
+        cf https://github.com/jupyter/oauthenticator/issues/28
+        """)
+
+
+    _carina_client = None
+    @property
+    def carina_client(self):
+        if self._carina_client is None:
+            self._carina_client = CarinaOAuthClient(self.client_id, self.client_secret, self.oauth_callback_url)
+
+        return self._carina_client
+
+    @gen.coroutine
+    def authenticate(self, handler):
+        authorization_code = handler.get_argument("code", False)
+        if not authorization_code:
+            raise web.HTTPError(400, "oauth callback made without a token")
+
+        yield self.carina_client.request_tokens(authorization_code)
+        profile = yield self.carina_client.get_user_profile()
+
+        carina_username = profile['username']
+
+        # map username to system username
+        system_username = self.username_map.get(carina_username, carina_username)
+
+        # check system username against whitelist
+        if self.whitelist and system_username not in self.whitelist:
+            system_username = None
+
+        return system_username

--- a/jupyterhub_carina/CarinaAuthenticator.py
+++ b/jupyterhub_carina/CarinaAuthenticator.py
@@ -1,32 +1,28 @@
 from tornado.auth import OAuth2Mixin
 from tornado import gen, web
-from traitlets import Dict
 from traitlets.config import LoggingConfigurable
 from oauthenticator import OAuthLoginHandler, OAuthenticator
 from .CarinaOAuthClient import CarinaOAuthClient
 
 
-class CarinaMixin(OAuth2Mixin):
+class CarinaLoginHandler(OAuthLoginHandler, OAuth2Mixin):
+    """
+    Carina OAuth dance magic
+    """
     _OAUTH_AUTHORIZE_URL = CarinaOAuthClient.CARINA_AUTHORIZE_URL
     _OAUTH_ACCESS_TOKEN_URL = CarinaOAuthClient.CARINA_TOKEN_URL
 
-
-class CarinaLoginHandler(OAuthLoginHandler, CarinaMixin):
     scope = ['identity', 'cluster_credentials', 'create_cluster']
 
 
 class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
+    """
+    Authenticate users with their Carina account.
+    """
+
     # Configure the base OAuthenticator
     login_service = 'Carina'
     login_handler = CarinaLoginHandler
-
-    # Expose configuration options
-    username_map = Dict(config=True, default_value={},
-                        help="""Optional dict to remap github usernames to system usernames.
-
-        User github usernames for keys and existing system usernames as values.
-        cf https://github.com/jupyter/oauthenticator/issues/28
-        """)
 
     _carina_client = None
     @property
@@ -38,9 +34,13 @@ class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
 
     @gen.coroutine
     def authenticate(self, handler):
+        """
+        Complete the OAuth dance and identify the user
+        """
+
         authorization_code = handler.get_argument("code", False)
         if not authorization_code:
-            raise web.HTTPError(400, "oauth callback made without a token")
+            raise web.HTTPError(400, "OAuth callback made without a token")
 
         yield self.carina_client.request_tokens(authorization_code)
         profile = yield self.carina_client.get_user_profile()
@@ -61,6 +61,7 @@ class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
         """
         Update the spawner with the OAuth credentials from the last time the user signed in
         """
+
         creds = self.carina_client.credentials
         if creds is None:
             return

--- a/jupyterhub_carina/CarinaOAuthClient.py
+++ b/jupyterhub_carina/CarinaOAuthClient.py
@@ -1,0 +1,224 @@
+import json
+import os
+from time import time, ctime
+from tornado import gen
+from tornado.httpclient import HTTPRequest, HTTPError, AsyncHTTPClient
+from traitlets.config import LoggingConfigurable
+import urllib
+from zipfile import ZipFile
+
+
+class CarinaOAuthCredentials:
+    def __init__(self, access_token, refresh_token, expires_at):
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.expires_at = expires_at
+
+    def is_expired(self):
+        return time() >= (self.expires_at + 60)
+
+
+class CarinaOAuthClient(LoggingConfigurable):
+    CARINA_OAUTH_HOST = os.environ.get('CARINA_OAUTH_HOST') or 'oauth.getcarina.com'
+    CARINA_AUTHORIZE_URL = "https://%s/oauth/authorize" % CARINA_OAUTH_HOST
+    CARINA_TOKEN_URL = "https://%s/oauth/token" % CARINA_OAUTH_HOST
+    CARINA_PROFILE_URL = "https://%s/me" % CARINA_OAUTH_HOST
+    CARINA_CLUSTERS_URL = "https://%s/clusters" % CARINA_OAUTH_HOST
+
+    def __init__(self, client_id, client_secret, callback_url, user='UNKNOWN'):
+        super().__init__()
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.callback_url = callback_url
+        self.credentials = None
+        self.user = user
+
+    def load_credentials(self, access_token, refresh_token, expires_at):
+        self.credentials = CarinaOAuthCredentials(access_token, refresh_token, expires_at)
+
+    @gen.coroutine
+    def request_tokens(self, authorization_code):
+        """
+        Exchange an authorization code for access and refresh tokens
+
+        See: https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples#post---oauthtoken
+        """
+
+        self.log.debug("Requesting oauth tokens")
+        body = {
+            'code': authorization_code,
+            'grant_type': 'authorization_code'
+        }
+
+        yield self.execute_token_request(body)
+
+    @gen.coroutine
+    def refresh_tokens(self):
+        """
+        Exchange a refresh token for a new set of tokens
+
+        See: https://github.com/doorkeeper-gem/doorkeeper/wiki/API-endpoint-descriptions-and-examples#curl-command-refresh-token-grant
+        """
+
+        self.log.info("Refreshing oauth tokens for %s", self.user)
+        body = {
+            'refresh_token': self.credentials.refresh_token,
+            'grant_type': 'refresh_token'
+        }
+
+        yield self.execute_token_request(body)
+
+    @gen.coroutine
+    def get_user_profile(self):
+        """
+        Determine who the logged in user is
+        """
+
+        self.log.debug("Retrieving the user profile")
+        request = HTTPRequest(
+            url=self.CARINA_PROFILE_URL,
+            method='GET',
+            headers={
+                'Accept': 'application/json',
+            })
+        response = yield self.execute_oauth_request(request)
+        result = json.loads(response.body.decode('utf8', 'replace'))
+        return result
+
+    @gen.coroutine
+    def create_cluster(self, cluster_name):
+        """
+        Create a Carina cluster
+        """
+
+        self.log.info("Creating cluster %s/%s", self.user, cluster_name)
+        request = HTTPRequest(
+            url=os.path.join(self.CARINA_CLUSTERS_URL, cluster_name),
+            method='PUT',
+            body='{}',
+            headers={
+                'Accept': 'application/json'
+            })
+
+        response = yield self.execute_oauth_request(request)
+        result = json.loads(response.body.decode('utf8', 'replace'))
+        return result
+
+    @gen.coroutine
+    def download_cluster_credentials(self, cluster_name, destination, polling_interval=30):
+        """
+        Download a cluster's credentials to the specified location.
+        """
+
+        self.log.info("Downloading cluster credentials for %s/%s", self.user, cluster_name)
+        request = HTTPRequest(
+            url=os.path.join(self.CARINA_CLUSTERS_URL, cluster_name),
+            method='GET',
+            headers={
+                'Accept': 'application/zip'
+            })
+
+        # Poll for the cluster credentials until the cluster is active
+        while True:
+            response = yield self.execute_oauth_request(request, raise_error=False)
+
+            if response.error is None:
+                self.log.debug("Credentials for %s/%s received.", self.user, cluster_name)
+                break
+
+            if response.code == 404 and "cluster is not yet active" in response.body.decode(encoding='UTF-8'):
+                self.log.debug("The %s/%s cluster is not yet active, retrying in %s seconds...",
+                               self.user, cluster_name, polling_interval)
+                yield gen.sleep(polling_interval)
+                continue
+
+            # abort, something bad happened!
+            self.log.error('An error occurred while downloading cluster credentials for %s/%s:\n(%s) %s\n%s',
+                           self.user, cluster_name, response.response.code, response.response.body, response.error)
+            response.rethrow
+
+        credentials_zip = ZipFile(response.buffer, "r")
+        credentials_zip.extractall(destination)
+        self.log.info("Credentials downloaded to %s", destination)
+
+    @gen.coroutine
+    def execute_token_request(self, body):
+        """
+        Requests a new set of OAuth tokens
+        """
+
+        body.update({
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'redirect_uri': self.callback_url
+        })
+
+        request = HTTPRequest(
+            url=self.CARINA_TOKEN_URL,
+            method='POST',
+            headers={
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body=urllib.parse.urlencode(body)
+        )
+
+        request_timestamp = time()
+        response = yield self.execute_request(request)
+
+        result = json.loads(response.body.decode('utf8', 'replace'))
+        self.credentials = CarinaOAuthCredentials(
+            access_token=result['access_token'],
+            refresh_token=result['refresh_token'],
+            expires_at=request_timestamp + int(result['expires_in']))
+
+    @gen.coroutine
+    def execute_oauth_request(self, request, raise_error=True):
+        """
+        Execute an OAuth request, retrying with a new set of tokens if the OAuth access token is expired or rejected
+        """
+
+        if self.credentials.is_expired():
+            self.log.info("The OAuth token for %s expired at %s", self.user, ctime(self.credentials.expires_at))
+            yield self.refresh_tokens()
+
+        self.authorize_request(request)
+
+        try:
+            return (yield self.execute_request(request, raise_error))
+        except HTTPError as e:
+            if e.response.code != 401:
+                raise
+
+            # Try once more with a new set of tokens
+            self.log.info("The OAuth token for %s were rejected", self.user)
+            yield self.refresh_tokens()
+            self.authorize_request(request)
+            return (yield self.execute_request(request, raise_error))
+
+    def authorize_request(self, request):
+        """
+        Add the Authorization header with the user's OAuth access token to a request
+        """
+
+        request.headers.update({
+                'Authorization': 'bearer {}'.format(self.credentials.access_token)
+            })
+
+    @gen.coroutine
+    def execute_request(self, request, raise_error=True):
+        """
+        Execute a HTTP request and log the error, if any
+        """
+
+        self.log.debug("%s %s", request.method, request.url)
+        http_client = AsyncHTTPClient()
+        request.headers.update({
+                'User-Agent': 'jupyterhub'
+            })
+        try:
+            return (yield http_client.fetch(request, raise_error=raise_error))
+        except HTTPError as e:
+            self.log.exception('An error occurred executing %s %s:\n(%s) %s',
+                               request.method, request.url, e.response.code, e.response.body)
+            raise

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -199,6 +199,7 @@ class CarinaSpawner(DockerSpawner):
         except requests.exceptions.RequestException:
             # Remove old credentials now that they no longer work
             shutil.rmtree(credentials_dir, ignore_errors=True)
+            self._client = None
             return False
 
     @gen.coroutine

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -1,0 +1,206 @@
+import docker
+from dockerspawner import DockerSpawner
+import os.path
+import re
+import requests
+from tornado import gen
+from traitlets import Unicode, Integer
+from .CarinaOAuthClient import CarinaOAuthClient
+
+
+class CarinaSpawner(DockerSpawner):
+
+    # Expose configuration
+    oauth_callback_url = Unicode(
+        os.getenv('OAUTH_CALLBACK_URL', ''),
+        config=True,
+        help="""Callback URL to use.
+        Typically `https://{host}/hub/oauth_callback`"""
+    )
+
+    client_id_env = 'OAUTH_CLIENT_ID'
+    client_id = Unicode(config=True)
+    def _client_id_default(self):
+        return os.getenv(self.client_id_env, '')
+
+    client_secret_env = 'OAUTH_CLIENT_SECRET'
+    client_secret = Unicode(config=True)
+    def _client_secret_default(self):
+        return os.getenv(self.client_secret_env, '')
+
+    cluster_name = Unicode(config=True, default_value='jupyterhub')
+
+    cluster_polling_interval = Integer(config=True, default_value=30)
+
+    extra_host_config = {
+        'volumes_from': ['swarm-data'],
+        'port_bindings': {8888: None},
+        'restart_policy': {
+            'MaximumRetryCount': 0,
+            'Name': 'always'
+        }
+    }
+
+    def __init__(self, **kwargs):
+        # Use a different docker client for each server
+        self._client = None
+        self._carina_client = None
+        
+        super().__init__(**kwargs)
+
+    @property
+    def client(self):
+        """
+        The Docker client used to connect to the user's Carina cluster
+        """
+
+        # TODO: Figure out how to configure this without overriding, or tweak a bit and call super
+        if self._client is None:
+            carina_dir = self.get_user_credentials_dir()
+            docker_env = os.path.join(carina_dir, 'docker.env')
+            if not os.path.exists(docker_env):
+                raise RuntimeError("ERROR! The credentials for {}/{} could not be found in {}.".format(
+                    self.user.name, self.cluster_name, carina_dir))
+
+            tls_config = docker.tls.TLSConfig(
+                client_cert=(os.path.join(carina_dir, 'cert.pem'),
+                             os.path.join(carina_dir, 'key.pem')),
+                ca_cert=os.path.join(carina_dir, 'ca.pem'),
+                verify=os.path.join(carina_dir, 'ca.pem'),
+                assert_hostname=False)
+            with open(docker_env) as f:
+                env = f.read()
+            docker_host = re.findall("DOCKER_HOST=tcp://(\d+\.\d+\.\d+\.\d+:\d+)", env)[0]
+            docker_host = 'https://' + docker_host
+            self._client = docker.Client(version='auto', tls=tls_config, base_url=docker_host)
+
+        return self._client
+
+    @property
+    def carina_client(self):
+        if self._carina_client is None:
+            # If we just authenticated, use the existing client which has the credentials loaded
+            # Otherwise, make a new client and assume that load_state is about to be called next with the credentials
+            if self.authenticator and self.authenticator.carina_client.credentials:
+                self.log.debug("Using the Carina client for %s from the CarinaAuthenticator", self.user.name)
+                self._carina_client = self.authenticator.carina_client
+                self._carina_client.user = self.user.name
+            else:
+                self.log.debug("Initializing a carina client for %s", self.user.name)
+                self._carina_client = CarinaOAuthClient(self.client_id, self.client_secret, self.oauth_callback_url, user=self.user.name)
+
+        return self._carina_client
+
+    def get_state(self):
+        self.log.debug("Saving state for %s", self.user.name)
+        state = super().get_state()
+        if self.carina_client.credentials:
+            state['access_token'] = self.carina_client.credentials.access_token
+            state['refresh_token'] = self.carina_client.credentials.refresh_token
+            state['expires_at'] = self.carina_client.credentials.expires_at
+
+        return state
+
+    def load_state(self, state):
+        self.log.debug("Loading state for %s", self.user.name)
+        super().load_state(state)
+
+        access_token = state.get('access_token', None)
+        refresh_token = state.get('refresh_token', None)
+        expires_at = state.get('expires_at', None)
+        if access_token:
+            self.log.debug("Loading users's oauth credentials")
+            self.carina_client.load_credentials(access_token, refresh_token, expires_at)
+
+    def clear_state(self):
+        self.log.debug("Clearing state")
+        super().clear_state()
+
+        # TODO: Move this to DockerSpawner
+        self.container_id = ''
+
+    @gen.coroutine
+    def get_container(self):
+        if not os.path.exists(self.get_user_credentials_dir()):
+            return None
+
+        if not self.cluster_exists():
+            return None
+
+        container = yield super().get_container()
+        return container
+
+    @gen.coroutine
+    def start(self):
+        try:
+            self.log.info("Creating notebook infrastructure for {}...".format(self.user.name))
+
+            yield self.create_cluster()
+            yield self.download_cluster_credentials()
+            yield self.pull_user_image()
+
+            self.log.info("Starting notebook container for {}...".format(self.user.name))
+            extra_env = {
+                'DOCKER_HOST': self.client.base_url.replace("https://", "tcp://"),
+                'DOCKER_TLS_VERIFY': 1,
+                'DOCKER_CERT_PATH': '/var/run/docker/'
+            }
+            extra_env.update(self.get_env())
+            extra_create_kwargs = {
+                'environment': extra_env
+            }
+
+            yield super().start(extra_create_kwargs=extra_create_kwargs)
+
+            self.log.debug('Startup for {} is complete!'.format(self.user.name))
+        except Exception as e:
+            self.log.exception('Startup for {} failed!'.format(self.user.name))
+            raise
+
+    @gen.coroutine
+    def create_cluster(self):
+        """
+        Create a Carina cluster.
+        The API will return the cluster information if it already exists,
+        so it's safe to call without checking if it exists first.
+        """
+        self.log.info("Creating cluster named: {} for {}".format(self.cluster_name, self.user.name))
+        yield self.carina_client.create_cluster(self.cluster_name)
+
+    @gen.coroutine
+    def download_cluster_credentials(self):
+        """
+        Download the cluster credentials
+        The API will return 404 if the cluster isn't available yet,
+        in which case the reqeust should be retried
+        """
+        credentials_dir = self.get_user_credentials_dir()
+        if os.path.exists(credentials_dir):
+            return
+
+        self.log.info("Downloading cluster credentials for {}/{}...".format(self.user.name, self.cluster_name))
+        user_dir = "/root/.carina/clusters/{}".format(self.user.name)
+        yield self.carina_client.download_cluster_credentials(self.cluster_name, user_dir, self.cluster_polling_interval)
+
+    @gen.coroutine
+    def cluster_exists(self):
+        try:
+            yield self.docker('info')
+            return True
+        except requests.exceptions.RequestException:
+            return False
+
+    @gen.coroutine
+    def pull_user_image(self):
+        """
+        Pull the user image to the cluster, so that it is ready to start instantly
+        """
+        self.log.debug("Starting to pull {} to the {}/{} cluster..."
+                       .format(self.container_image, self.user.name, self.cluster_name))
+        yield self.docker("pull", self.container_image)
+        self.log.debug("Finished pulling {} to the {}/{} cluster..."
+                       .format(self.container_image, self.user.name, self.cluster_name))
+
+    def get_user_credentials_dir(self):
+        credentials_dir = "/root/.carina/clusters/{}/{}".format(self.user.name, self.cluster_name)
+        return credentials_dir

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -11,7 +11,7 @@ from .CarinaOAuthClient import CarinaOAuthClient
 
 class CarinaSpawner(DockerSpawner):
     """
-    Spawn the user's Jupyter server on their Carina cluster.
+    Spawn the user's Jupyter server on their Carina cluster
     """
 
     cluster_name = Unicode(
@@ -62,7 +62,6 @@ class CarinaSpawner(DockerSpawner):
         """
         The Docker client used to connect to the user's Carina cluster
         """
-
         # TODO: Figure out how to configure this without overriding, or tweak a bit and call super
         if self._client is None:
             carina_dir = self.get_user_credentials_dir()
@@ -161,9 +160,10 @@ class CarinaSpawner(DockerSpawner):
     @gen.coroutine
     def create_cluster(self):
         """
-        Create a Carina cluster.
+        Create a Carina cluster
+
         The API will return the cluster information if it already exists,
-        so it's safe to call without checking if it exists first.
+        so it's safe to call without first checking if the cluster exists.
         """
         self.log.info("Creating cluster named: {} for {}".format(self.cluster_name, self.user.name))
         yield self.carina_client.create_cluster(self.cluster_name)
@@ -172,8 +172,9 @@ class CarinaSpawner(DockerSpawner):
     def download_cluster_credentials(self):
         """
         Download the cluster credentials
+
         The API will return 404 if the cluster isn't available yet,
-        in which case the reqeust should be retried
+        in which case the request should be retried.
         """
         credentials_dir = self.get_user_credentials_dir()
         if os.path.exists(credentials_dir):
@@ -188,7 +189,6 @@ class CarinaSpawner(DockerSpawner):
         """
         Safely check if the user's cluster exists
         """
-
         credentials_dir = self.get_user_credentials_dir()
         if not os.path.exists(credentials_dir):
             return False
@@ -205,7 +205,7 @@ class CarinaSpawner(DockerSpawner):
     @gen.coroutine
     def pull_user_image(self):
         """
-        Pull the user image to the cluster, so that it is ready to start instantly
+        Pull the user image to the cluster
         """
         self.log.debug("Starting to pull {} to the {}/{} cluster..."
                        .format(self.container_image, self.user.name, self.cluster_name))

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -10,7 +10,7 @@ from .CarinaOAuthClient import CarinaOAuthClient
 
 class CarinaSpawner(DockerSpawner):
     cluster_name = Unicode(config=True, default_value='jupyterhub')
-
+    container_name = Unicode(config=True, default_value='jupyter')
     cluster_polling_interval = Integer(config=True, default_value=30)
 
     # Override the default timeout to allow extra time for creating the cluster and pulling the server image

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -7,10 +7,14 @@ from tornado import gen
 from traitlets import Unicode, Integer
 from .CarinaOAuthClient import CarinaOAuthClient
 
+
 class CarinaSpawner(DockerSpawner):
     cluster_name = Unicode(config=True, default_value='jupyterhub')
 
     cluster_polling_interval = Integer(config=True, default_value=30)
+
+    # Override the default timeout to allow extra time for creating the cluster and pulling the server image
+    start_timeout = Integer(config=True, default_value=300, help=DockerSpawner.start_timeout.help)
 
     extra_host_config = {
         'volumes_from': ['swarm-data'],

--- a/jupyterhub_carina/__init__.py
+++ b/jupyterhub_carina/__init__.py
@@ -1,0 +1,2 @@
+from .CarinaAuthenticator import *
+from .CarinaSpawner import *

--- a/jupyterhub_carina/_version.py
+++ b/jupyterhub_carina/_version.py
@@ -1,0 +1,15 @@
+"""jupyterhub_carina version info"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+version_info = (
+    0,
+    1,
+    0,
+    'dev', # comment-out this line for a release
+)
+__version__ = '.'.join(map(str, version_info[:3]))
+
+if len(version_info) > 3:
+    __version__ = '%s%s' % (__version__, version_info[3])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dockerspawner
-jupyterhub
-oauthenticator
+dockerspawner>=0.3.0
+jupyterhub>=0.5.0
+oauthenticator>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dockerspawner
+jupyterhub
+oauthenticator

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+#-----------------------------------------------------------------------------
+# Minimal Python version sanity check (from IPython/Jupyterhub)
+#-----------------------------------------------------------------------------
+from __future__ import print_function
+
+import os
+import sys
+
+v = sys.version_info
+if v[:2] < (3,3):
+    error = "ERROR: Jupyter Hub requires Python version 3.3 or above."
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
+
+if os.name in ('nt', 'dos'):
+    error = "ERROR: Windows is not supported"
+    print(error, file=sys.stderr)
+
+# At least we're on the python version we need, move on.
+
+from distutils.core import setup
+
+pjoin = os.path.join
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Get the current package version.
+version_ns = {}
+with open(pjoin(here, 'jupyterhub_carina', '_version.py')) as f:
+    exec(f.read(), {}, version_ns)
+
+
+setup_args = dict(
+    name                = 'jupyterhub-carina',
+    packages            = ['jupyterhub_carina'],
+    version             = version_ns['__version__'],
+    description         = """Carina support for JupyterHub""",
+    long_description    = "Authenticate users with Carina and run their servers on their own Carina clusters.",
+    author              = "Jupyter Development Team",
+    author_email        = "jupyter@googlegroups.com",
+    url                 = "https://jupyter.org",
+    license             = "BSD",
+    platforms           = "Linux, Mac OS X",
+    keywords            = ['Interactive', 'Interpreter', 'Shell', 'Web', 'Carina'],
+    classifiers         = [
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+    ],
+)
+
+if 'bdist_wheel' in sys.argv:
+    import setuptools
+
+# setuptools requirements
+if 'setuptools' in sys.modules:
+    setup_args['install_requires'] = install_requires = []
+    with open('requirements.txt') as f:
+        for line in f.readlines():
+            req = line.strip()
+            if not req or req.startswith(('-e', '#')):
+                continue
+            install_requires.append(req)
+
+
+def main():
+    setup(**setup_args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is the initial implementation of jupyterhub-carina from howtowhale (see https://github.com/jupyterhub/jupyterhub/issues/524), plus all the bug fixes that magically came to me once I realized someone else will use the code. :smile: 

The [README](https://github.com/carolynvs/jupyterhub-carina/blob/d209bb5a6518dec8b246fd9315c931b0f78f55b3/README.md) covers how to sign up for a Carina OAuth account and configure the plugin.

It handles recovering from some things well, like expired OAuth tokens, and others, like deleting the Carina cluster while the user's Jupyter server was still running, not so much. I am still hammering out how [best to avoid 503 and 504 proxy errors](https://github.com/carolynvs/howtowhale/pull/26) when that happens.
