### PR TITLE
Support new authenticator signature

### DIFF
--- a/jupyterhub_carina/CarinaAuthenticator.py
+++ b/jupyterhub_carina/CarinaAuthenticator.py
@@ -34,7 +34,7 @@ class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):
         return self._carina_client
 
     @gen.coroutine
-    def authenticate(self, handler):
+    def authenticate(self, handler, data=None):
         """
         Complete the OAuth dance and identify the user
         """


### PR DESCRIPTION
The 0.4 release of oauthenticator introduced a new parameter to the authenticate function. See https://github.com/jupyterhub/oauthenticator/commit/d9a007a663b84abf48411cb164ff18b31eea3f41 for the upstream change that prompted this.

@minrk @willingc @rgbkrk  Is this the best way to deal with breaking changes introduced from other packages? I'm not quite sure if the requirements for `jupyterhub-carina` should require a specific version of its dependecies, e.g. `oauthenticator==0.3.0`, or if instead I should update the signature of the functions to not break when extra args are introduced?
