### PR TITLE
Don't throw exceptions from poll

### DIFF
--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -54,7 +54,7 @@ class CarinaSpawner(DockerSpawner):
         # Use a different docker client for each server
         self._client = None
         self._carina_client = None
-        
+
         super().__init__(**kwargs)
 
     @property
@@ -196,7 +196,7 @@ class CarinaSpawner(DockerSpawner):
         try:
             yield self.docker('info')
             return True
-        except requests.exceptions.RequestException:
+        except Exception:
             # Remove old credentials now that they no longer work
             shutil.rmtree(credentials_dir, ignore_errors=True)
             self._client = None


### PR DESCRIPTION
When polling for the server status, if we can't connect to the cluster, do not throw an exception, instead cleanly report that it is gone so that we can start a new server.

Currently, when your server is borked, because say the cluster was deleted ( :smiling_imp: ), deleting the server doesn't work so it's difficult to start over fresh.

```
[E 2016-05-17 20:31:05.888 JupyterHub web:1524] Uncaught exception DELETE /jupyter/hub/api/users/carolynvs/server (207.91.176.135)
    HTTPServerRequest(protocol='http', host='howtowhale.com', method='DELETE', uri='/jupyter/hub/api/users/carolynvs/server', version='HTTP/1.1', remote_ip='207.91.176.135', headers={'Accept-Encoding': 'gzip, deflate, br', 'X-Forwarded-Port': '80', 'X-Nginx-Proxy': 'true', 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:45.0) Gecko/20100101 Firefox/45.0', 'Dnt': '1', 'Cookie': 'jupyter-hub-token="2|1:0|10:1463426613|17:jupyter-hub-token|44:ZjdiYjJhMDhiMTU4NGMxZGIxZGZhMDM3NjYzMGZkNWM=|ff45f83dce833905558544a1c36842bdaec159df0ea9717114b381967968d754"', 'Accept-Language': 'en-US,en;q=0.5', 'X-Forwarded-For': '207.91.176.135,172.17.0.3', 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', 'Accept': '*/*', 'X-Real-Ip': '207.91.176.135', 'Host': 'howtowhale.com', 'Referer': 'https://howtowhale.com/jupyter/hub/home', 'Connection': 'close', 'X-Forwarded-Proto': 'http', 'Content-Length': '0'})
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.5/site-packages/tornado/web.py", line 1445, in _execute
        result = yield result
      File "/opt/conda/lib/python3.5/types.py", line 179, in throw
        return self.__wrapped.throw(tp, *rest)
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/apihandlers/users.py", line 183, in delete
        status = yield user.spawner.poll()
      File "/opt/conda/lib/python3.5/site-packages/dockerspawner/dockerspawner.py", line 304, in poll
        container = yield self.get_container()
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub_carina/CarinaSpawner.py", line 128, in get_container
        if not (yield self.cluster_exists()):
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub_carina/CarinaSpawner.py", line 197, in cluster_exists
        yield self.docker('info')
      File "/opt/conda/lib/python3.5/concurrent/futures/_base.py", line 398, in result
        return self.__get_result()
      File "/opt/conda/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
        raise self._exception
      File "/opt/conda/lib/python3.5/concurrent/futures/thread.py", line 55, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/opt/conda/lib/python3.5/site-packages/dockerspawner/dockerspawner.py", line 291, in _docker
        m = getattr(self.client, method)
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub_carina/CarinaSpawner.py", line 83, in client
        self._client = docker.Client(version='auto', tls=tls_config, base_url=docker_host)
      File "/opt/conda/lib/python3.5/site-packages/docker/client.py", line 81, in __init__
        self._version = self._retrieve_server_version()
      File "/opt/conda/lib/python3.5/site-packages/docker/client.py", line 105, in _retrieve_server_version
        'Error while fetching server API version: {0}'.format(e)
    docker.errors.DockerException: Error while fetching server API version: HTTPSConnectionPool(host='146.20.68.25', port=2376): Max retries exceeded with url: /version (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f2a5578c438>, 'Connection to 146.20.68.25 timed out. (connect timeout=60)'))
```
