### PR TITLE
[WIP]Whale in a Box

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,2 @@
+secrets.sh
+secrets.ps1

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,135 @@
+# Whale in a Box
+Want to run a workshop or class? Don't want to waste time setting up and troubleshooting
+everyone's snowflake laptops?
+
+This will get you setup with your own JupyterHub instance, running on Carina.
+Each participant can log in with their Carina account to have their own pre-setup sandbox,
+with any Jupyter notebooks and materials included.
+
+# Prerequisites
+* A Carina account. If you do not already have one, create a free account (no credit card required)
+  by following the [sign up process](https://app.getcarina.com/app/signup).
+* Your Carina API key. To get it, go to the [Carina Control Panel](https://app.getcarina.com),
+  click your username in the top-right corner, and then click API Key.
+
+# Installation
+1. Download or clone this repository.
+1. Open a terminal in the `demo` subdirectory.
+1. Create a file to contain secret credentials. Do **not** check-in this file.
+
+    **Bash**
+
+    Name the file `secrets.sh` and add the following content:
+
+    ```bash
+    export CARINA_USERNAME=username
+    export CARINA_APIKEY=apikey
+    ```
+
+    **PowerShell**
+
+    Name the file `secrets.ps1` and add the following content:
+
+    ```powershell
+    $env:CARINA_USERNAME="username"
+    $env:CARINA_APIKEY="apikey"
+    ```  
+1. Run the following command to perform one-time setup for the workshop infrastructure:
+
+    **Bash**
+
+    ```bash
+    $ ./setup.sh
+
+    ```
+
+    **PowerShell**
+
+    ```powershell
+    > .\setup.sh
+    ```
+1. The output contains the IP address of the workshop website. If you have a
+    domain for the workshop, update your DNS and add an A record pointing to the IP address.
+    Depending on TTL settings, this will a few minutes or longer.
+
+    You can determine when the entry is ready by running the following command,
+    replacing `<myDomain>` with your domain name:
+
+    **Bash**
+
+    ```bash
+    $ dig +short <myDomain>
+    172.99.73.144
+    ```
+
+    **PowerShell**
+
+    ```powershell
+    > nslookup <myDomain>
+    Server:  FIOS_Quantum_Gateway.fios-router.home
+    Address:  192.168.1.1
+
+    Non-authoritative answer:
+    Name:    <myDomain>
+    Address:  172.99.73.144
+    ```
+
+1. Go to your domain, or the IP address and verify that the website works.
+1. [Register the website with Carina OAuth](https://getcarina.com/docs/reference/oauth-integration/#register-your-application).
+    For the **Callback URL** use `https://<domain-or-ip>/jupyter/hub/oauth_callback`.
+1. Add your Carina OAuth credentials to the secrets file.
+
+    **Bash**
+
+    Edit `secrets.sh` and add the following content:
+
+    ```bash
+    export CARINA_OAUTH_CLIENT_ID=application-id
+    export CARINA_OAUTH_CLIENT_SECRET=secret
+    ```
+
+    **PowerShell**
+
+    Edit `secrets.ps1` and add the following content:
+
+    ```poweshell
+    $env:CARINA_OAUTH_CLIENT_ID="application-id"
+    $env:CARINA_OAUTH_CLIENT_SECRET="secret"
+    ```
+1. Customize the settings file following the directions in the file.
+    If you are using PowerShell, edit `settings.ps1`, otherwise `settings.sh`.
+1. Run the following command to create the workshop website. This command can be
+    rerun at any time to update the website assets, workshop materials, or just fix things
+    if they break.
+
+    **Bash**
+
+    ```bash
+    $ ./run.sh
+    ```
+
+    **PowerShell**
+
+    ```powershell
+    > .\run.sh
+    ```
+
+# Customization
+This is a mighty fine boxed whale, ready to be taken home and turned into your very
+own howtowhale. Most things are tweakable without having to delve into the deployment
+infrastructure.
+
+## Materials
+Add Jupyter notebooks and other materials to `jupyter/materials` and redeploy.
+
+## Landing Page
+Edit `web/index.html` and redeploy.
+
+## Jupyter Server
+Edit `jupyter/Dockerfile` to either swap out the base Jupyter notebook server image
+or add dependencies.
+
+* Change `FROM jupyter/minimal-notebook` to another
+base Jupyter notebook server of your choice. I recommend selecting one from the
+[Jupyter Docker Stacks project](https://github.com/jupyter/docker-stacks#a-visual-overview-of-stacks).
+* Add `RUN <command>` to install additional dependencies, for example `RUN apt-get update && apt-get install -y curl` or `RUN pip install pandas`.

--- a/demo/data/Dockerfile
+++ b/demo/data/Dockerfile
@@ -1,0 +1,6 @@
+FROM cirros
+
+RUN mkdir -p /etc/certs/ && \
+    mkdir -p /etc/letsencrypt/webrootauth/
+
+ENTRYPOINT /bin/true

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,74 @@
+version: '2'
+services:
+  data: # Holds our certificates and other data that needs to stay the same between rebuilds
+    build:
+      context: data
+      args:
+        - "constraint:node==*-n1"
+    container_name: jupyterhub-data
+    volumes:
+      - /etc/certs
+      - /etc/letsencrypt
+      - /etc/jupyterhub
+    environment:
+      - "constraint:node==*-n1"
+  letsencrypt: # Handles generating and reissuing Let's Encrypt certificates
+    build:
+      context: letsencrypt
+      args:
+        - "constraint:node==*-n1"
+        - DOCKER_VERSION
+    container_name: letsencrypt
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    volumes_from:
+      - data
+    environment:
+      - "constraint:node==*-n1"
+      - DOMAIN=$JUPYTERHUB_DOMAIN
+      - EMAIL=$LETSENCRYPT_EMAIL
+      - USE_PRODUCTION=$LETSENCRYPT_USE_PRODUCTION
+  jupyterhub:
+    build:
+      context: jupyterhub
+      args:
+        - "constraint:node==*-n1"
+    container_name: jupyterhub
+    ports:
+      # TODO: Route this through nginx
+      - '8081:8081'
+    #restart: always
+    volumes_from:
+      - data
+    environment:
+      - "constraint:node==*-n1"
+      - DOMAIN=$JUPYTERHUB_DOMAIN
+      - JUPYTERHUB_ADMINS
+      - JUPYTER_IMAGE
+      - OAUTH_CLIENT_ID=$CARINA_OAUTH_CLIENT_ID
+      - OAUTH_CLIENT_SECRET=$CARINA_OAUTH_CLIENT_SECRET
+  web: # The landing page for the website
+    build:
+      context: web
+      args:
+        - "constraint:node==*-n1"
+    container_name: website
+    environment:
+      - "constraint:node==*-n1"
+  proxy: # Directs traffic to the website, letsencrypt, jupyterhub and user servers
+    build:
+      context: proxy
+      args:
+        - "constraint:node==*-n1"
+        - DOMAIN=$JUPYTERHUB_DOMAIN
+    container_name: nginx
+    ports:
+      - '80:80'
+      - '443:443'
+    #restart: always
+    volumes_from:
+      - data
+      - web
+    environment:
+      - "constraint:node==*-n1"
+      - DOMAIN=$JUPYTERHUB_DOMAIN

--- a/demo/jupyter/Dockerfile
+++ b/demo/jupyter/Dockerfile
@@ -1,0 +1,15 @@
+# Select a notebook type from https://github.com/jupyter/docker-stacks#a-visual-overview-of-stacks
+FROM jupyter/minimal-notebook
+
+# Add workshop materials such as Jupyter notebooks and supporting files
+ADD materials/* /home/jovyan/work/
+
+# Install additional dependencies
+# RUN apt-get update && apt-get install -y <package>
+# RUN pip install <package>
+
+# Workaround for https://github.com/getcarina/feedback/issues/31#issuecomment-185523037
+USER root
+
+# Use the JupyterHub-friendly startup script
+CMD ["/usr/local/bin/start-singleuser.sh"]

--- a/demo/jupyter/materials/Welcome.ipynb
+++ b/demo/jupyter/materials/Welcome.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"helo world\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/demo/jupyterhub/Dockerfile
+++ b/demo/jupyterhub/Dockerfile
@@ -1,0 +1,9 @@
+FROM jupyter/jupyterhub:0.5.0
+
+# Install jupyterhub-carina plugin
+ADD requirements.txt /tmp
+RUN pip install -U -r /tmp/requirements.txt
+
+# Perform one-time setup if needed, then start JupyterHub
+COPY run.sh /
+CMD ["/run.sh"]

--- a/demo/jupyterhub/README.md
+++ b/demo/jupyterhub/README.md
@@ -1,0 +1,34 @@
+1. Run the following command to create a data volume container to store
+    your certificates:
+
+    ```bash
+    docker run \
+      --name letsencrypt-data \
+      --volume /etc/letsencrypt \
+      --volume /var/lib/letsencrypt \
+      --entrypoint /bin/mkdir \
+      quay.io/letsencrypt/letsencrypt \
+      -p /etc/letsencrypt/webrootauth/
+    ```
+1. Run the following command to generate certificates:
+
+    ```bash
+    docker run \
+      --rm \
+      --volumes-from letsencrypt-data \
+      --publish 443:443 \
+      --publish 80:80 \
+      quay.io/letsencrypt/letsencrypt certonly \
+      --server https://acme-v01.api.letsencrypt.org/directory \
+      --domain dev.howtowhale.com \
+      --authenticator standalone \
+      --email me@carolynvanslyck.com \
+      --agree-tos
+    ```
+
+docker run -it --name test \
+  -p 8000:8000 \
+  -e GITHUB_CLIENT_ID= \
+  -e GITHUB_CLIENT_SECRET= \
+  -e OAUTH_CALLBACK_URL=http://jupyterhub.carolynvs.com/hub/oauth_callback \
+  carolynvs/jupyterhub-carina

--- a/demo/jupyterhub/jupyterhub_config.py
+++ b/demo/jupyterhub/jupyterhub_config.py
@@ -1,0 +1,25 @@
+import os
+
+# Load environment variables
+domain = os.getenv("DOMAIN")
+admin_users = os.getenv("JUPYTERHUB_ADMINS")
+jupyter_image = os.getenv("JUPYTER_IMAGE")
+
+c = get_config()
+c.JupyterHub.base_url = "/jupyter"
+c.JupyterHub.confirm_no_ssl = True
+
+# Configure JupyterHub to authenticate against Carina
+c.JupyterHub.authenticator_class = "jupyterhub_carina.CarinaAuthenticator"
+c.CarinaAuthenticator.admin_users = [admin_users]
+c.CarinaAuthenticator.oauth_callback_url = "https://{}/jupyter/hub/oauth_callback".format(domain)
+
+# Configure JupyterHub to spawn user servers on Carina
+c.JupyterHub.hub_ip = "0.0.0.0"
+c.JupyterHub.spawner_class = "jupyterhub_carina.CarinaSpawner"
+c.CarinaSpawner.hub_ip_connect = domain
+c.CarinaSpawner.container_image = jupyter_image
+
+# Save data outside of the JupyterHub directory to survive between rebuilds
+c.JupyterHub.cookie_secret_file = "/etc/jupyterhub/cookie_secret"
+c.JupyterHub.db_url = "/etc/jupyterhub/jupyterhub.sqlite"

--- a/demo/jupyterhub/requirements.txt
+++ b/demo/jupyterhub/requirements.txt
@@ -1,0 +1,2 @@
+oauthenticator==0.4.0
+jupyterhub-carina==0.1.1

--- a/demo/jupyterhub/run.sh
+++ b/demo/jupyterhub/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generate a persistant cookie for JupyterHub
+echo "Checking for a JupyterHub cookie secret..."
+if [ ! -f /etc/jupyterhub/cookie_secret ]; then
+    echo "Initializing a new cookie secret"
+    mkdir -p /etc/jupyterhub
+    openssl rand -base64 2048 > /etc/jupyterhub/cookie_secret
+    chmod 600 /etc/jupyterhub/cookie_secret
+fi
+
+echo "Initialization Complete - Staring JupyterHub"
+exec jupyterhub --no-ssl -f /srv/jupyterhub/jupyterhub_config.py

--- a/demo/letsencrypt/Dockerfile
+++ b/demo/letsencrypt/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine
+
+# Install curl
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+    
+# Configure cron
+COPY reissue.sh /generate-certificate.sh
+RUN ln -s /generate-certificate.sh /etc/periodic/monthly/reissue && \
+    chmod a+x /etc/periodic/monthly/reissue
+
+# Install the docker client
+ARG DOCKER_VERSION
+ADD https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz /tmp
+RUN cd /tmp && \
+    tar -xzf /tmp/docker-$DOCKER_VERSION.tgz && \
+    cp /tmp/docker/docker /usr/local/bin/docker
+
+COPY run.sh /run.sh
+RUN chmod 777 /run.sh
+WORKDIR /
+CMD ["/run.sh"]

--- a/demo/letsencrypt/reissue.sh
+++ b/demo/letsencrypt/reissue.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -euo pipefail
+
+echo "Generating a Let's Encrypt certificate for $DOMAIN..."
+if [ "$USE_PRODUCTION" = true ]; then
+  LETSENCRYPT_SERVER="https://acme-v01.api.letsencrypt.org/directory"
+else
+  echo "Using the Let's Encrypt staging server"
+  LETSENCRYPT_SERVER="https://acme-staging.api.letsencrypt.org/directory"
+fi
+
+docker run --rm \
+  --volumes-from jupyterhub-data \
+  quay.io/letsencrypt/letsencrypt certonly \
+  --server $LETSENCRYPT_SERVER \
+  --domain $DOMAIN \
+  --authenticator webroot \
+  --webroot-path /etc/letsencrypt/webrootauth/ \
+  --email $EMAIL \
+  --renew-by-default \
+  --agree-tos
+
+# Copy the certificate to the volume shared with nginx
+cp /etc/letsencrypt/live/$DOMAIN/privkey.pem /etc/certs/jupyterhub.key
+cp /etc/letsencrypt/live/$DOMAIN/fullchain.pem /etc/certs/jupyterhub.crt
+
+# Send nginx a SIGHUP to trigger it to reload its configuration without shutting down.
+echo "Reloading nginx configuration"
+docker kill --signal=HUP nginx

--- a/demo/letsencrypt/run.sh
+++ b/demo/letsencrypt/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -euo pipefail
+
+# Wait for nginx as our Let's Encrypt challenge is served by it
+echo "Waiting for nginx to start..."
+until $(curl --output /dev/null --silent --head --fail --insecure https://$DOMAIN); do
+    printf '.'
+    sleep 5
+done
+echo ""
+
+# Generate a Let's Encrypt certificate
+echo "Checking for a Let's Encrypt certificate"
+if [ ! -f "/etc/letsencrypt/live/$DOMAIN/privkey.pem" ]; then
+  /generate-certificate.sh
+fi
+
+echo "Initialization Complete - Starting the Let's Encrypt cron job"
+# Start CRON
+exec /usr/sbin/crond -f -d 8

--- a/demo/proxy/Dockerfile
+++ b/demo/proxy/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx
+
+ARG DOMAIN
+
+ADD default.conf /etc/nginx/conf.d/default.conf
+ADD run.sh /run.sh
+
+RUN sed -i "s/DOMAIN/${DOMAIN}/g" /etc/nginx/conf.d/default.conf
+
+CMD ["/run.sh"]

--- a/demo/proxy/default.conf
+++ b/demo/proxy/default.conf
@@ -1,0 +1,84 @@
+server {
+    listen         80;
+    server_name    DOMAIN;
+
+    # This is necessary for issuing the initial certificate
+    location /.well-known/acme-challenge {
+        alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
+        location ~ /.well-known/acme-challenge/(.*) {
+            add_header Content-Type application/jose+json;
+        }
+    }
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_certificate /etc/certs/jupyterhub.crt;
+    ssl_certificate_key /etc/certs/jupyterhub.key;
+
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    ssl_dhparam /etc/certs/dhparams.pem;
+
+    # modern configuration. tweak to your needs.
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    add_header Strict-Transport-Security max-age=15768000;
+
+    # OCSP Stapling ---
+    # fetch OCSP records from URL in ssl_certificate and cache them
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    resolver 8.8.8.8 8.8.4.4 valid=86400;
+
+    location / {
+        root /var/www/html;
+    }
+
+    location /jupyter {
+        proxy_pass http://jupyterhub:8000;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header X-NginX-Proxy true;
+    }
+
+    location ~* /(user/[^/]*)/(api/kernels/[^/]+/channels|terminals/websocket)/? {
+        proxy_pass http://jupyterhub:8000;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header X-NginX-Proxy true;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
+
+    # This is necessary for reissuing the certificate
+    location /.well-known/acme-challenge {
+        alias /etc/letsencrypt/webrootauth/.well-known/acme-challenge;
+        location ~ /.well-known/acme-challenge/(.*) {
+            add_header Content-Type application/jose+json;
+        }
+    }
+}

--- a/demo/proxy/run.sh
+++ b/demo/proxy/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generate a self-signed certificate
+echo "Checking for an existing TLS certificate"
+if [[ ! -f /etc/certs/jupyterhub.key ]]; then
+  echo "Generating a self-signed certificate..."
+  touch /etc/certs/jupyterhub.key
+  openssl req -x509 -newkey rsa:2048 -days 365 -nodes -batch \
+    -keyout /etc/certs/jupyterhub.key \
+    -out /etc/certs/jupyterhub.crt
+fi
+
+# Generate strong Diffie-Hellman parameters
+echo "Checking for existing Diffie-Hellman parameters"
+if [ ! -f "/etc/certs/dhparams.pem" ]; then
+  echo "Generating Diffie-Hellman parameters. This will take a few minutes..."
+  openssl dhparam -out /etc/certs/dhparams.pem 2048
+fi
+
+echo "Initialization Complete - Starting nginx"
+exec /usr/sbin/nginx -g "daemon off;"

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Figure out the current directory
+__SCRIPT_SOURCE="$_"
+if [ -n "$BASH_SOURCE" ]; then
+  __SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+fi
+DIR="$(cd "$(dirname "${__SCRIPT_SOURCE:-$0}")" > /dev/null && \pwd)"
+unset __SCRIPT_SOURCE 2> /dev/null
+
+# Load secret credentials
+source $DIR/secrets.sh
+
+# Load settings
+source $DIR/settings.sh
+
+# Connect to the Carina cluster
+eval $(carina env $JUPYTERHUB_CLUSTER)
+
+# Cleanup old containers
+docker rm -f nginx jupyterhub letsencrypt &> /dev/null || true
+
+# Build and publish the custom Docker image used by the user's Jupyter server
+docker build -t $JUPYTER_IMAGE jupyter
+docker push $JUPYTER_IMAGE
+
+# Do all the things with a sidecar of stuff
+docker-compose build
+docker-compose up -d
+docker-compose logs -f

--- a/demo/settings.sh
+++ b/demo/settings.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# JupyterHub
+#
+
+# A space separate list of Carina usernames that should be administrators
+# Maps to JupyterHub.Authenticator.admin_users
+# Example: myname@example.com arackspaceusername
+export JUPYTERHUB_ADMINS=
+
+# The Jupyter server image setup for each user.
+# Maps to DockerSpawner.container_image
+# Example: dockerhubusername/myworkshop
+export JUPYTER_IMAGE=
+
+#
+# TLS - If you are not using a domain, leave the variables below blank
+#
+
+# The domain of the workshop
+# Example: example.com
+export JUPYTERHUB_DOMAIN=
+
+# The email address which owns the domain
+# Example: myname@example.com
+# Used in letsencrypt/reissue.sh
+export LETSENCRYPT_EMAIL=
+
+#
+# Random - These are all optional settings with which you can customize your Whale in a Box
+#
+
+# The carina cluster name where jupyterhub should be deployed. Do not use jupyterhub, or else you will cross the streams!
+# Used in setup.sh
+export JUPYTERHUB_CLUSTER=whale-in-a-box
+
+# Specifies if production/trusted or staging/untrusted certificate should be generated.
+# Staging certs don't count against your rate limit and should be used when first testing this out.
+# Used in letsencrypt/reissue.sh
+export LETSENCRYPT_USE_PRODUCTION=true

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Figure out the current directory
+__SCRIPT_SOURCE="$_"
+if [ -n "$BASH_SOURCE" ]; then
+  __SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+fi
+DIR="$(cd "$(dirname "${__SCRIPT_SOURCE:-$0}")" > /dev/null && \pwd)"
+unset __SCRIPT_SOURCE 2> /dev/null
+
+# Load secret credentials
+source $DIR/secrets.sh
+
+# Load settings
+source $DIR/settings.sh
+
+echo "Performing one-time setup"
+
+# Install carina
+if ! type carina > /dev/null; then
+  echo "Installing the carina cli"
+  curl -L https://download.getcarina.com/carina/latest/$(uname -s)/$(uname -m)/carina > /usr/local/bin/carina
+  chmod +x /usr/local/bin/carina
+fi
+
+# Install dvm
+if ! type dvm > /dev/null; then
+  echo "Installing dvm"
+  curl -sL https://download.getcarina.com/dvm/latest/install.sh | sh
+  source ~/.dvm/dvm.sh
+fi
+
+# Install docker-compose
+if ! type docker-compose > /dev/null; then
+  echo "Installing docker-compose"
+  curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+fi
+
+# Create a cluster on Carina
+if ! carina get $JUPYTERHUB_CLUSTER 2>&1 | grep -q $JUPYTERHUB_CLUSTER &> /dev/null; then
+  echo "Creating a Carina cluster..."
+  carina create --wait $JUPYTERHUB_CLUSTER
+fi
+eval $(carina env $JUPYTERHUB_CLUSTER)
+
+# Use the right docker client for the cluster
+dvm use &> /dev/null
+
+# Login to Docker Hub
+docker login
+
+# Print out the IP address of the cluster
+# TODO: Since we have their api key already, check if they have a Rackspace DNS entry for this domain
+# If so, prompt to add/update the A record on their behalf, and then wait for the DNS change to propogate
+printf "\n##########\n"
+echo "All done!"
+echo "If you are running JupyterHub with a domain name, add an A record to your DNS now pointing to the IP address below:"
+printf "##########\n"
+docker run --rm --net=host -e constraint:node==*-n1 racknet/ip public ipv4

--- a/demo/web/Dockerfile
+++ b/demo/web/Dockerfile
@@ -1,0 +1,6 @@
+FROM cirros
+
+ADD html /var/www/html
+VOLUME /var/www/html
+
+ENTRYPOINT /bin/true

--- a/demo/web/html/index.html
+++ b/demo/web/html/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Cool Workshop</title>
+  </head>
+
+  <body>
+    <h1>Cool Workshop</h1>
+    <p>This is a really cool workshop where you will learn lots of stuff <em>and</em> things.</p>
+    <h2>Instructions</h2>
+    <ol>
+      <li><a href="https://getcarina.com">Create a free account on Carina</a>.</li>
+      <li><a href="/jupyter">Log into the workshop</a> and open the NOTEBOOK.</li>
+    </ol>
+  </body>
+</html>


### PR DESCRIPTION
It amuses me to call this "Whale in a Box" because this is essentially howtowhale deconstructed for anyone to replicate and customize. When I tried making a single Docker image for people to run, I didn't like how it came out because it left important things like SSL certificates as an exercise to the reader.  It would be neat to update howtowhale to use this as a base, so that howtowhale runs on whaleinabox, proving that it works.

You can see the result of running the scripts at [whaleinabox.carolynvs.com](https://whaleinabox.carolynvs.com).

This is the initial prototype (or brain dump). Some instructions are in the README but comments/documentation needs to be fleshed out more, scripts tested/hardened, and possibly explain more potentially useful configuration settings. 

I still need to work out what should be distributed in the repo for people to build locally and customize, and what should be published to Docker Hub. Right now I'm thinking that `demo/jupyterhub`, `demo/proxy`, `demo/letsencrypt` and `demo/data` could be published, leaving `demo/web` and `demo/jupyter` to be copied locally by the user and custom built.

I have placeholders for PowerShell scripts in the doc but won't add them until the bash scripts are how we'd like them. Then I'll make corresponding PowerShell scripts to match.

Closes #3.

/cc @willingc @rgbkrk 
