### PR TITLE
Refresh plugin to work with latest version of Carina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 ## 0.1.0
 First release
+
+## 0.1.1
+* Improve error handling when user cluster is deleted (#4)
+* Support JupyterHub/OAuthenticator 0.4 (#2)
+
+## 0.2.0
+Support new release of Carina (http://ui.getcarina.com)

--- a/jupyterhub_carina/CarinaAuthenticator.py
+++ b/jupyterhub_carina/CarinaAuthenticator.py
@@ -13,7 +13,7 @@ class CarinaLoginHandler(OAuthLoginHandler, OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = CarinaOAuthClient.CARINA_AUTHORIZE_URL
     _OAUTH_ACCESS_TOKEN_URL = CarinaOAuthClient.CARINA_TOKEN_URL
 
-    scope = ['identity', 'cluster_credentials', 'create_cluster']
+    scope = ['identity', 'read', 'write', 'execute']
 
 
 class CarinaAuthenticator(OAuthenticator, LoggingConfigurable):

--- a/jupyterhub_carina/CarinaOAuthClient.py
+++ b/jupyterhub_carina/CarinaOAuthClient.py
@@ -6,7 +6,7 @@ from tornado.httpclient import HTTPRequest, HTTPError, AsyncHTTPClient
 from traitlets.config import LoggingConfigurable
 import urllib
 from zipfile import ZipFile
-
+from ._version import __version__
 
 class CarinaOAuthCredentials:
     """
@@ -107,10 +107,10 @@ class CarinaOAuthClient(LoggingConfigurable):
             url=self.CARINA_CLUSTERS_URL,
             method='POST',
             body=json.dumps({
-              "cluster_type_id": template_id,
-              "node_count": 1,
-              "name": cluster_name
-            }),
+                      "cluster_type_id": template_id,
+                      "node_count": 1,
+                      "name": cluster_name
+                      }),
             headers={
                 'Content-Type': 'application/json',
                 'Accept': 'application/json'
@@ -257,8 +257,8 @@ class CarinaOAuthClient(LoggingConfigurable):
         Add the Authorization header with the user's OAuth access token to a request
         """
         request.headers.update({
-                'Authorization': 'bearer {}'.format(self.credentials.access_token)
-            })
+            'Authorization': 'bearer {}'.format(self.credentials.access_token)
+        })
 
     @gen.coroutine
     def execute_request(self, request, raise_error=True):
@@ -269,8 +269,8 @@ class CarinaOAuthClient(LoggingConfigurable):
         self.log.debug("%s %s", request.method, request.url)
         http_client = AsyncHTTPClient()
         request.headers.update({
-                'User-Agent': 'jupyterhub'
-            })
+            'User-Agent': 'jupyterhub-carina/' + __version__
+        })
         try:
             return (yield http_client.fetch(request, raise_error=raise_error))
         except HTTPError as e:

--- a/jupyterhub_carina/CarinaOAuthClient.py
+++ b/jupyterhub_carina/CarinaOAuthClient.py
@@ -177,7 +177,7 @@ class CarinaOAuthClient(LoggingConfigurable):
                                self.user, cluster_name, cluster_id)
                 break
 
-            if response.code == 404 and "cluster is not yet active" in response.body.decode(
+            if response.code == 404 and "Cluster credentials do not exist" in response.body.decode(
                     encoding='UTF-8'):
                 self.log.debug("The %s/%s (%s) cluster is not yet active, retrying in %s "
                                "seconds...", self.user, cluster_name, cluster_id, polling_interval)

--- a/jupyterhub_carina/CarinaOAuthClient.py
+++ b/jupyterhub_carina/CarinaOAuthClient.py
@@ -234,7 +234,8 @@ class CarinaOAuthClient(LoggingConfigurable):
         Retry with a new set of tokens when the OAuth access token is expired or rejected
         """
         if self.credentials.is_expired():
-            self.log.info("The OAuth token for %s expired at %s", self.user, ctime(self.credentials.expires_at))
+            self.log.info("The OAuth token for %s expired at %s", self.user,
+                          ctime(self.credentials.expires_at))
             yield self.refresh_tokens()
 
         self.authorize_request(request)

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -166,7 +166,7 @@ class CarinaSpawner(DockerSpawner):
         so it's safe to call without first checking if the cluster exists.
         """
         self.log.info("Creating cluster named: {} for {}".format(self.cluster_name, self.user.name))
-        yield self.carina_client.create_cluster(self.cluster_name)
+        return (yield self.carina_client.create_cluster(self.cluster_name))
 
     @gen.coroutine
     def download_cluster_credentials(self):

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -2,7 +2,6 @@ import docker
 from dockerspawner import DockerSpawner
 import os.path
 import re
-import requests
 import shutil
 from tornado import gen
 from traitlets import Dict, Integer, Unicode
@@ -19,7 +18,8 @@ class CarinaSpawner(DockerSpawner):
         help="The name of the user's Carina cluster.",
         config=True)
 
-    # Override the default container name. Since we are running on the user's cluster, we don't need the username suffix
+    # Override the default container name. Since we are running on the user's cluster, we don't
+    # need the username suffix
     container_name = Unicode(
         'jupyter',
         help="The name of the Jupyter server container running on the user's cluster.",
@@ -31,7 +31,8 @@ class CarinaSpawner(DockerSpawner):
         config=True
     )
 
-    # Override the default timeout to allow extra time for creating the cluster and pulling the server image
+    # Override the default timeout to allow extra time for creating the cluster and pulling the
+    # server image
     start_timeout = Integer(
         300,
         help=DockerSpawner.start_timeout.help,
@@ -41,8 +42,8 @@ class CarinaSpawner(DockerSpawner):
     extra_host_config = Dict(
         {
             'volumes_from': ['swarm-data'],  # --volumes-from swarm-data
-            'port_bindings': {8888: None},   # -p 8888:8888
-            'restart_policy': {              # --restart always
+            'port_bindings': {8888: None},  # -p 8888:8888
+            'restart_policy': {  # --restart always
                 'MaximumRetryCount': 0,
                 'Name': 'always'
             },
@@ -67,8 +68,9 @@ class CarinaSpawner(DockerSpawner):
             carina_dir = self.get_user_credentials_dir()
             docker_env = os.path.join(carina_dir, 'docker.env')
             if not os.path.exists(docker_env):
-                raise RuntimeError("ERROR! The credentials for {}/{} could not be found in {}.".format(
-                    self.user.name, self.cluster_name, carina_dir))
+                raise RuntimeError(
+                    "ERROR! The credentials for {}/{} could not be found in {}.".format(
+                        self.user.name, self.cluster_name, carina_dir))
 
             tls_config = docker.tls.TLSConfig(
                 client_cert=(os.path.join(carina_dir, 'cert.pem'),
@@ -90,7 +92,8 @@ class CarinaSpawner(DockerSpawner):
             self.log.debug("Initializing a carina client for %s", self.user.name)
             # Load OAuth configuration from the authenticator
             cfg = self.authenticator
-            self._carina_client = CarinaOAuthClient(cfg.client_id, cfg.client_secret, cfg.oauth_callback_url,
+            self._carina_client = CarinaOAuthClient(cfg.client_id, cfg.client_secret,
+                                                    cfg.oauth_callback_url,
                                                     user=self.user.name)
 
         return self._carina_client

--- a/jupyterhub_carina/__init__.py
+++ b/jupyterhub_carina/__init__.py
@@ -1,2 +1,3 @@
 from .CarinaAuthenticator import *
 from .CarinaSpawner import *
+from ._version import __version__

--- a/jupyterhub_carina/_version.py
+++ b/jupyterhub_carina/_version.py
@@ -5,8 +5,8 @@
 
 version_info = (
     0,
-    1,
-    1,
+    2,
+    0,
     'dev', # comment-out this line for a release
 )
 __version__ = '.'.join(map(str, version_info[:3]))


### PR DESCRIPTION
This updates the jupyterhub-carina plugin to work with the new release of Carina. Essentially the api changed a bit:

* Create a cluster: `PUT /clusters/<clusterName>` -> `POST /clusters` with the params in the body
* Create requires a cluster template which can be found with `GET /cluster_types`. I'm just picking the most recent Docker Swarm cluster type.
* Download credentials: `GET /clusters/<clusterName>` -> `GET /clusters/clusterId>/credentials/zip`
* OAuth scopes were renamed
  * read: do readonly things like list clusters
  * write: create/delete clusters
  * execute: download cluster credentials, i.e. execute code on the users' clusters 
* Updated user agent string to reflect the plugin version