### PR TITLE
Do not create duplicate clusters

### DIFF
--- a/jupyterhub_carina/CarinaOAuthClient.py
+++ b/jupyterhub_carina/CarinaOAuthClient.py
@@ -214,7 +214,7 @@ class CarinaOAuthClient(LoggingConfigurable):
                 '(%s) %s\n%s',
                 self.user, cluster_name, cluster_id,
                 response.code, response.body, response.error)
-            response.rethrow
+            raise response.error
 
         credentials_zip = ZipFile(response.buffer, "r")
         credentials_zip.extractall(destination)

--- a/jupyterhub_carina/CarinaOAuthClient.py
+++ b/jupyterhub_carina/CarinaOAuthClient.py
@@ -151,6 +151,30 @@ class CarinaOAuthClient(LoggingConfigurable):
         return template_id
 
     @gen.coroutine
+    def get_cluster(self, cluster_name):
+        """
+        Retrieve a Carina cluster by name
+        Returns None if it doesn't exist
+        """
+        self.log.info("Retrieving cluster %s/%s ", self.user, cluster_name)
+        request = HTTPRequest(
+            url=self.CARINA_CLUSTERS_URL,
+            method='GET',
+            headers={
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            })
+
+        response = yield self.execute_oauth_request(request)
+        result = json.loads(response.body.decode('utf8', 'replace'))
+
+        for cluster in result['clusters']:
+            if cluster['name'] == cluster_name:
+                return cluster
+
+        return None
+
+    @gen.coroutine
     def download_cluster_credentials(self, cluster_id, cluster_name, destination,
                                      polling_interval=30):
         """

--- a/jupyterhub_carina/CarinaSpawner.py
+++ b/jupyterhub_carina/CarinaSpawner.py
@@ -164,8 +164,14 @@ class CarinaSpawner(DockerSpawner):
     def create_cluster(self):
         """
         Create a Carina cluster
+        Returns existing cluster if one with the same name is already present
         """
-        self.log.info("Creating cluster named: {} for {}".format(self.cluster_name, self.user.name))
+        cluster = yield self.carina_client.get_cluster(self.cluster_name)
+        if cluster is not None:
+            self.log.info("Found existing cluster: {}/{}".format(self.user.name, self.cluster_name))
+            return cluster
+
+        self.log.info("Creating cluster {}/{}".format(self.user.name, self.cluster_name))
         return (yield self.carina_client.create_cluster(self.cluster_name))
 
     @gen.coroutine


### PR DESCRIPTION
The old Carina API would "ignore" requests to create a cluster if there was already a cluster with the same name (because the primary key was the cluster name). Now that clusters can exist with the same name, we need to check first if it exists, and skip the call to create.

Fixes #7 